### PR TITLE
CMOB-1147 Release 3.33.1

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -4,7 +4,7 @@ pluginManagement {
         google()
     }
     plugins {
-        id 'com.fyber.fairbid-sdk-plugin' version '3.32.0'
+        id 'com.fyber.fairbid-sdk-plugin' version '3.+'
         id 'com.android.application'
         id 'kotlin-android'
     }


### PR DESCRIPTION
CMOB-1147

Taking the chance of updating the sample apps to actually work on SDKTOOLS-1154

From now on, by default, the sample should build against the latest minor.