### PR TITLE
HZANDRO-3710_bump_fairBid_min_os_to_19: bump min OS to 19

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This sample app demonstrates the FairBid SDK integration best practices. It is a
 Please note that when it comes to actually demonstrating the product "FairBid" as a monetization platform this sample app might fail due to the fact that ad delivery depends on factors like your country, your device your AAID/IDFA or any other kind of information that ad networks might have collected about you and that are taken into consideration when placing a bid to show an ad to you.
 
 #### Prerequisites
-* Minimum SDK 16 (Jelly Bean 4.1.x) 
+* Minimum SDK 19 (KitKat 4.4) 
 * Android build plugin 3.4.2 / Gradle 5.4.1 / Kotlin 1.3.61 
 
 #### Navigating the sample code

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,7 +26,7 @@ android {
 
     defaultConfig {
         applicationId "com.fyber.fairbid.sample"
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 33
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
HZANDRO-3710

Next FairBid version (3.63.0) will impose minimum api 19